### PR TITLE
API 호출 부분 리팩토링

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,11 @@
+import React from 'react';
 import Router from './Router';
-import { useEffect, useState } from 'react';
+
+import useQuery from './hooks/useQuery';
 import apis from './apis';
 
 function App() {
-  const [user, setUser] = useState(null);
-  useEffect(() => {
-    apis.users.get().then((data) => setUser(data));
-  }, []);
+  const user = useQuery('user', () => apis.users.get());
   return <Router user={user} />;
 }
 

--- a/src/apis/users.js
+++ b/src/apis/users.js
@@ -6,7 +6,7 @@ const users = {
     if (!auth.isLoggedIn()) {
       return;
     }
-    return request.get('/users').catch(() => auth.clear());
+    return await request.get('/users').catch(() => auth.clear());
   },
 
   async login(values) {

--- a/src/components/Header/Category.jsx
+++ b/src/components/Header/Category.jsx
@@ -1,24 +1,15 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import apis from '../../apis';
+import useQuery from '../../hooks/useQuery';
 
 import './Category.scss';
 
 export default function Category() {
-  const [categories, setCategories] = useState(null);
+  const categories = useQuery('category', () => apis.categories.getAll());
   const [hoveredCategory, setHoveredCategory] = useState(-1);
   const isHovered = useMemo(() => hoveredCategory !== -1, [hoveredCategory]);
   const dropdownRef = useRef(null);
-
-  useEffect(() => {
-    apis.categories.getAll().then((data) => setCategories(data));
-  }, []);
 
   const renderSubCategories = useCallback(() => {
     const subCategories = categories[hoveredCategory].sub_categories;

--- a/src/components/Header/Category.jsx
+++ b/src/components/Header/Category.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import apis from '../../apis';
 import useQuery from '../../hooks/useQuery';
@@ -21,13 +22,14 @@ export default function Category() {
     return (
       <div className="category__sub-dropdown" style={{ height }}>
         {subCategories.map(({ id, name }) => (
-          <div
+          <Link
             key={name + id}
+            to={`/products?category=${id}`}
             className="category__sub-dropdown__item"
             data-id={id}
           >
             {name}
-          </div>
+          </Link>
         ))}
       </div>
     );
@@ -46,15 +48,16 @@ export default function Category() {
       <span className="category__text">카테고리</span>
       <div className="category__dropdown" ref={dropdownRef}>
         {categories?.map(({ id, name }) => (
-          <div
+          <Link
             key={name + id}
+            to={`/products?category=${id}`}
             className={
               'category__dropdown__item ' + (hoveredCategory === id && 'active')
             }
             onMouseEnter={handleMouseEnter(id)}
           >
             {name}
-          </div>
+          </Link>
         ))}
       </div>
       {isHovered && renderSubCategories()}

--- a/src/hooks/useQuery.js
+++ b/src/hooks/useQuery.js
@@ -1,0 +1,22 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useEffect, useState } from 'react';
+
+export default function useQuery(
+  key = '',
+  api = () => new Promise(),
+  config = {}
+) {
+  const { initialData, onSucess = () => {}, onFail = () => {} } = config;
+  const [data, setData] = useState(initialData);
+
+  useEffect(() => {
+    api()
+      .then((result) => {
+        setData(result);
+        onSucess(result);
+      })
+      .catch((err) => onFail(err));
+  }, [key]);
+
+  return data;
+}

--- a/src/hooks/useQuery.js
+++ b/src/hooks/useQuery.js
@@ -6,14 +6,14 @@ export default function useQuery(
   api = () => new Promise(),
   config = {}
 ) {
-  const { initialData, onSucess = () => {}, onFail = () => {} } = config;
+  const { initialData, onSuccess = () => {}, onFail = () => {} } = config;
   const [data, setData] = useState(initialData);
 
   useEffect(() => {
     api()
       .then((result) => {
         setData(result);
-        onSucess(result);
+        onSuccess(result);
       })
       .catch((err) => onFail(err));
   }, [key]);

--- a/src/pages/Baskets/index.jsx
+++ b/src/pages/Baskets/index.jsx
@@ -4,6 +4,7 @@ import Button from '../../components/Button';
 import Checkbox from './Checkbox';
 import BasketItem from './BasketItem';
 
+import useQuery from '../../hooks/useQuery';
 import apis from '../../apis';
 import auth from '../../utils/auth';
 
@@ -27,13 +28,12 @@ export default function BasketsPage() {
     [deliveryCharge, discountPrice, isGuest, price]
   );
 
-  useEffect(() => {
-    (async () => {
-      const baskets = await apis.baskets.getAll();
-      setBaskets(baskets);
-      setSelected(baskets.map(({ id }) => id));
-    })();
-  }, []);
+  useQuery('baskets', () => apis.baskets.getAll(), {
+    onSuccess: (data) => {
+      setBaskets(data);
+      setSelected(data.map(({ id }) => id));
+    },
+  });
 
   useEffect(() => {
     const priceInfo = baskets.map(({ id, product, amount }) => ({

--- a/src/pages/Main/Banner/index.jsx
+++ b/src/pages/Main/Banner/index.jsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import useCarousel from '../../../hooks/useCarousel';
+import useQuery from '../../../hooks/useQuery';
 import apis from '../../../apis';
 
 import './Banner.scss';
-
 export default function Banner() {
   const {
     data: promotions,
@@ -16,9 +16,9 @@ export default function Banner() {
   } = useCarousel({ infinite: true });
   const [isHover, setIsHover] = useState(false);
 
-  useEffect(() => {
-    apis.promotions.getAll().then((data) => setPromotions(data));
-  }, [setPromotions]);
+  useQuery('promotinos', () => apis.promotions.getAll(), {
+    onSuccess: setPromotions,
+  });
 
   useEffect(() => {
     if (isHover) return;

--- a/src/pages/Main/index.jsx
+++ b/src/pages/Main/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import ProductListItem from '../../components/ProductListItem';
 import Banner from './Banner';
@@ -7,6 +7,7 @@ import apis from '../../apis';
 import useCarousel from '../../hooks/useCarousel';
 
 import './MainPage.scss';
+import useQuery from '../../hooks/useQuery';
 
 export default function MainPage() {
   const {
@@ -18,9 +19,9 @@ export default function MainPage() {
   } = useCarousel();
   const carouselLength = useMemo(() => products.length / 4, [products]);
 
-  useEffect(() => {
-    apis.products.getAll().then((data) => setProducts(data));
-  }, [setProducts]);
+  useQuery('products', () => apis.products.getAll(), {
+    onSuccess: setProducts,
+  });
 
   const handleClickLeftButton = () => {
     moveCarousel(-1);

--- a/src/pages/Product/index.jsx
+++ b/src/pages/Product/index.jsx
@@ -1,27 +1,26 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import Button from '../../components/Button';
 import AmountInput from '../../components/AmountInput';
 
+import useQuery from '../../hooks/useQuery';
 import apis from '../../apis';
 
 import './ProductPage.scss';
 
 export default function ProductPage() {
   const { id } = useParams();
-  const [product, setProduct] = useState({
-    title: '',
-    thumbnail: '',
-    description: '',
-    price: 0,
-    salesPrice: 0,
+  const product = useQuery(`products/${id}`, () => apis.products.get(id), {
+    initialData: {
+      title: '',
+      thumbnail: '',
+      description: '',
+      price: 0,
+      salesPrice: 0,
+    },
   });
   const [amount, setAmount] = useState(1);
-
-  useEffect(() => {
-    apis.products.get(id).then((data) => setProduct(data));
-  }, [id]);
 
   const handleAmountInput = (value) => {
     setAmount(value);

--- a/src/pages/Products/index.jsx
+++ b/src/pages/Products/index.jsx
@@ -10,15 +10,15 @@ import './ProductsPage.scss';
 
 export default function ProductsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const isASC = useMemo(
-    () => searchParams.get('order') === 'asc',
+  const isDESC = useMemo(
+    () => searchParams.get('order') === 'desc',
     [searchParams]
   );
 
   const orderProducts = useCallback(
-    (isASC) => (products) => {
+    (isDESC) => (products) => {
       return products.sort((a, b) =>
-        isASC ? a.salesPrice - b.salesPrice : b.salesPrice - a.salesPrice
+        isDESC ? b.salesPrice - a.salesPrice : a.salesPrice - b.salesPrice
       );
     },
     []
@@ -29,7 +29,7 @@ export default function ProductsPage() {
     () => apis.products.getAll(searchParams),
     {
       initialData: [],
-      onSuccess: orderProducts(isASC),
+      onSuccess: orderProducts(isDESC),
     }
   );
   const category = useQuery(
@@ -53,7 +53,7 @@ export default function ProductsPage() {
         <div className="products__header__order">
           <span
             className={
-              'products__header__order__method ' + (isASC ? 'active' : '')
+              'products__header__order__method ' + (isDESC ? '' : 'active')
             }
             onClick={handleClickOrder('asc')}
           >
@@ -62,7 +62,7 @@ export default function ProductsPage() {
           <div className="products__header__order__separator" />
           <span
             className={
-              'products__header__order__method ' + (isASC ? '' : 'active')
+              'products__header__order__method ' + (isDESC ? 'active' : '')
             }
             onClick={handleClickOrder('desc')}
           >


### PR DESCRIPTION
`useQuery`를 이용해 `useState`의 이용 빈도를 낮춤

필요한 경우에만 `useState`와 `useQuery`를 함께 사용
- 데이터 fetching 후 클라이언트 내에서 해당 데이터를 변경하는 경우 (장바구니)